### PR TITLE
doc: add winget instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,17 @@
 
 # 📘 Installation
 
+## Windows
+
+Installer: Download the .exe or .msi file from the latest release on https://github.com/vjousse/pomodorolm/releases/
+
+winget: `winget install pomodorolm`
+
 ## Archlinux
 
     yay -S pomodorolm-bin
 
-## Windows, Mac OS X, Debian, AppImage
+## Mac OS X, Debian, AppImage
 
 Download the install file for your OS from the latest release on https://github.com/vjousse/pomodorolm/releases/
 


### PR DESCRIPTION
Updated installation instructions for Windows by specifying which files to get on Windows, added winget package. Placed this new Windows heading to the top of the installation options, as it's the most popular platform.